### PR TITLE
feat: add panel icon

### DIFF
--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -6,6 +6,7 @@ webui: "http://[HOST]:[PORT:8428]/"
 ingress: true
 ingress_port: 8428
 ingress_entry: /vmui
+panel_icon: mdi:chart-timeline
 # host_network: true
 ports:
   8428/tcp: 8428


### PR DESCRIPTION
Add icon when using ingress; purposely avoided the `mdi:chart-areaspline` that InfluxDB uses (and visually similar) to avoid confusion.