### PR TITLE
feat: InfluxDB add-on parity; use tmpfs

### DIFF
--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -1,11 +1,13 @@
 name: Victoria Metrics
-version: "1.8.21"
+version: "1.8.22"
 slug: victoria_metrics
 description: Time Series Database for long term storage as replacement for Prometheus and InfluxDB
 webui: "http://[HOST]:[PORT:8428]/"
+startup: services
 ingress: true
 ingress_port: 8428
 ingress_entry: /vmui
+hassio_api: true
 # host_network: true
 ports:
   8428/tcp: 8428
@@ -16,6 +18,7 @@ arch:
   - amd64
 #  - i386
 init: false
+tmpfs: true
 map:
   - share:rw
 options:


### PR DESCRIPTION
Startup with services and expose hassio_api for parity with the InfluxDB add-on; allow use of tmpfs to possibly prevent unnecessary disk wear.

Also bumps version.